### PR TITLE
Fix for missing attribute 'inline_instances' for django >=1.4

### DIFF
--- a/data_exports/admin.py
+++ b/data_exports/admin.py
@@ -16,7 +16,7 @@ class ColumnInline(admin.TabularInline):
 
 class ExportAdmin(admin.ModelAdmin):
     inlines = [ColumnInline]
-    list_display = ['name', 'slug', 'model', 'export_format']
+    list_display = ['name', 'slug', 'model', 'export_format', 'get_export_link']
     list_filter = ['export_format', 'model']
     prepopulated_fields = {"slug": ("name",)}
     readonly_fields = ['model']

--- a/data_exports/admin.py
+++ b/data_exports/admin.py
@@ -31,6 +31,8 @@ class ExportAdmin(admin.ModelAdmin):
     def get_formsets(self, request, obj=None):
         if obj is None:
             return
+        if not hasattr(self, 'inline_instances'):
+            self.inline_instances = self.get_inline_instances(request)
         for inline in self.inline_instances:
             yield inline.get_formset(request, obj)
 

--- a/data_exports/models.py
+++ b/data_exports/models.py
@@ -36,6 +36,13 @@ class Export(models.Model):
     def get_absolute_url(self):
         return reverse('data_exports:export_view', kwargs={'slug': self.slug})
 
+    def get_export_link(self):
+        if self.slug:
+            return '<a href="%s">Download</a>' % self.get_absolute_url()
+        else:
+            return 'Export not ready'
+    get_export_link.allow_tags = True
+
 
 class Column(models.Model):
     export = models.ForeignKey(Export)


### PR DESCRIPTION
Apparently in django 1.4 or newer the `get_inline_instances` method is not being called before `get_formsets` so I made a dirty little fix to check if proper attribute is set and set it manually if it's not. I did not test this on django <1.4. 
